### PR TITLE
FCM data only messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This service acts as an intermediary between Bisq clients and Apple Push Notification service (APNs)
-or Firebase Cloud Messaging (FCM) in order to send push notifications to the mobile app.
+or Firebase Cloud Messaging (FCM) to send push notifications to the mobile app.
 More documentation can be found [here](https://github.com/bisq-network/bisqremote/wiki).
 
 ## Building the Source Code
@@ -19,7 +19,7 @@ There are two ways to clone it before it can be built:
   git clone --recursive  https://github.com/bisq-network/bisq-relay.git
 ```
 
-2. Do a normal clone, and pull down the bisq repo dependency with two git submodule commands:
+2. Do a normal clone and pull down the bisq repo dependency with two git submodule commands:
 ```sh
   git clone https://github.com/bisq-network/bisq-relay.git
   cd bisq-relay
@@ -37,7 +37,7 @@ There are two ways to clone it before it can be built:
 
 ### Requirements
 
-Prior to running the service, several files need to be obtained in order to be able to
+Before running the service, several files need to be obtained to be able to
 send push notifications to APNs and FCM, and ultimately to the corresponding mobile app.
 
 #### FCM
@@ -47,6 +47,14 @@ under `project settings` > `service accounts`.
 
 > Note, the Android app needs to be built with a corresponding `google-services.json` file
 > for the same Firebase project.
+
+By default, the relay sends basic notifications that are only processed by the app when clicked on.
+If you want to send "data-only" messages, allowing the mobile app to receive and process messages
+in the background and control how/if it wants to show a notification to the user, you can set the
+`BISQ_RELAY_FCM_DATA_ONLY` environment variable to `true`.
+
+> For more details about messages and notifications,
+> see: https://firebase.google.com/docs/cloud-messaging/android/receive
 
 #### APNs
 An appropriate `apnsCertificate.p12` file needs to be copied to the root folder, along with the
@@ -77,11 +85,12 @@ The service is configured via environment variables. The following variables are
 
 #### FCM Configuration
 
-| Environment Variable | Description | Default |
-|---------------------|-------------|---------|
-| `BISQ_RELAY_FCM_ENABLED` | Enable FCM push notifications | `false` |
+| Environment Variable                         | Description                                                   | Default  |
+|----------------------------------------------|---------------------------------------------------------------|----------|
+| `BISQ_RELAY_FCM_ENABLED`                     | Enable FCM push notifications                                 | `false`  |
 | `BISQ_RELAY_FCM_FIREBASE_CONFIGURATION_FILE` | Path to Firebase service account JSON (required when enabled) | _(none)_ |
-| `BISQ_RELAY_FCM_FIREBASE_URL` | Firebase database URL (required when enabled) | _(none)_ |
+| `BISQ_RELAY_FCM_FIREBASE_URL`                | Firebase database URL (required when enabled)                 | _(none)_ |
+| `BISQ_RELAY_FCM_DATA_ONLY`                   | Enable sending FCM data-only messages                         | `false`  |
 
 ### Run the Script
 

--- a/src/main/java/bisq/relay/config/FcmProperties.java
+++ b/src/main/java/bisq/relay/config/FcmProperties.java
@@ -29,6 +29,7 @@ import org.springframework.validation.annotation.Validated;
  *   <li>{@code BISQ_RELAY_FCM_ENABLED} - Whether FCM is enabled (default: false)</li>
  *   <li>{@code BISQ_RELAY_FCM_FIREBASE_CONFIGURATION_FILE} - Path to Firebase service account JSON file</li>
  *   <li>{@code BISQ_RELAY_FCM_FIREBASE_URL} - Firebase database URL</li>
+ *   <li>{@code BISQ_RELAY_FCM_DATA_ONLY} - Whether to send FCM data-only messages (default: false)</li>
  * </ul>
  */
 @Validated
@@ -55,6 +56,12 @@ public class FcmProperties {
     @NotBlank(message = "FCM Firebase URL must be configured. Set BISQ_RELAY_FCM_FIREBASE_URL environment variable.")
     private String firebaseUrl;
 
+    /**
+     * Whether to send FCM data-only messages.
+     * Default is {@code false} - must be explicitly enabled.
+     */
+    private boolean sendDataOnly = false;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -78,5 +85,12 @@ public class FcmProperties {
     public void setFirebaseUrl(String firebaseUrl) {
         this.firebaseUrl = firebaseUrl;
     }
-}
 
+    public boolean isSendDataOnly() {
+        return sendDataOnly;
+    }
+
+    public void setSendDataOnly(boolean sendDataOnly) {
+        this.sendDataOnly = sendDataOnly;
+    }
+}

--- a/src/main/java/bisq/relay/notification/apns/ApnsPushNotificationSender.java
+++ b/src/main/java/bisq/relay/notification/apns/ApnsPushNotificationSender.java
@@ -77,7 +77,7 @@ public class ApnsPushNotificationSender implements PushNotificationSender {
                 .setClientCredentials(appleCertFile, appleCertPassword)
                 .build();
 
-        LOG.info("APNS client is ready to push notifications (sandbox={})", apnsProperties.isUseSandbox());
+        LOG.info("APNs client is ready to push notifications (sandbox={})", apnsProperties.isUseSandbox());
     }
 
     @VisibleForTesting

--- a/src/main/java/bisq/relay/notification/fcm/FcmPushNotificationBuilder.java
+++ b/src/main/java/bisq/relay/notification/fcm/FcmPushNotificationBuilder.java
@@ -17,6 +17,7 @@
 
 package bisq.relay.notification.fcm;
 
+import bisq.relay.config.FcmProperties;
 import bisq.relay.notification.PushNotificationMessage;
 import com.google.firebase.messaging.AndroidConfig;
 import com.google.firebase.messaging.Message;
@@ -24,6 +25,7 @@ import com.google.firebase.messaging.Notification;
 import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -37,9 +39,17 @@ public class FcmPushNotificationBuilder {
     // The maximum time-to-live duration of an Android message is 4 weeks
     public static final long TTL_DAYS = 28;
 
+    private final FcmProperties fcmProperties;
+
+    @Autowired
+    public FcmPushNotificationBuilder(final FcmProperties fcmProperties) {
+        this.fcmProperties = fcmProperties;
+    }
+
     public Message buildMessage(
             @Nonnull final PushNotificationMessage pushNotificationMessage,
-            @Nonnull final String deviceToken) {
+            @Nonnull final String deviceToken
+    ) {
         Objects.requireNonNull(deviceToken);
         Objects.requireNonNull(pushNotificationMessage);
 
@@ -52,6 +62,13 @@ public class FcmPushNotificationBuilder {
             LOG.warn("PushNotificationMessage is missing encrypted content: {}", pushNotificationMessage);
         }
 
+        if (!fcmProperties.isSendDataOnly()) {
+            messageBuilder.setNotification(Notification.builder()
+                    .setTitle("You have received a Bisq notification")
+                    .setBody("Click to decrypt")
+                    .build());
+        }
+
         return messageBuilder.build();
     }
 
@@ -61,11 +78,7 @@ public class FcmPushNotificationBuilder {
         AndroidConfig androidConfig = getAndroidConfig(pushNotificationMessage);
 
         return Message.builder()
-                .setAndroidConfig(androidConfig)
-                .setNotification(Notification.builder()
-                        .setTitle("You have received a Bisq notification")
-                        .setBody("Click to decrypt")
-                        .build());
+                .setAndroidConfig(androidConfig);
     }
 
     private AndroidConfig getAndroidConfig(@Nonnull final PushNotificationMessage pushNotificationMessage) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,20 +3,23 @@
 #########################################################################################
 server.address=0.0.0.0
 server.port=8080
+
 #########################################################################################
-## FCM configuration
+## Firebase Cloud Messaging (FCM) configuration
 ##
 ## Environment variables:
 ##   BISQ_RELAY_FCM_ENABLED - Enable FCM (default: false)
 ##   BISQ_RELAY_FCM_FIREBASE_CONFIGURATION_FILE - Path to Firebase service account JSON (required when enabled)
 ##   BISQ_RELAY_FCM_FIREBASE_URL - Firebase database URL (required when enabled)
+##   BISQ_RELAY_FCM_DATA_ONLY - Enable sending FCM data-only messages (default: false)
 #########################################################################################
 fcm.enabled=${BISQ_RELAY_FCM_ENABLED:false}
 fcm.firebaseConfigurationFile=${BISQ_RELAY_FCM_FIREBASE_CONFIGURATION_FILE:}
 fcm.firebaseUrl=${BISQ_RELAY_FCM_FIREBASE_URL:}
+fcm.sendDataOnly=${BISQ_RELAY_FCM_DATA_ONLY:false}
 
 #########################################################################################
-## APNs configuration
+## Apple Push Notification service (APNs) configuration
 ##
 ## Environment variables:
 ##   BISQ_RELAY_APNS_BUNDLE_ID - iOS app bundle identifier (required)

--- a/src/test/java/bisq/relay/notification/fcm/FcmPushNotificationSenderTest.java
+++ b/src/test/java/bisq/relay/notification/fcm/FcmPushNotificationSenderTest.java
@@ -17,35 +17,41 @@
 
 package bisq.relay.notification.fcm;
 
+import bisq.relay.config.FcmProperties;
 import bisq.relay.notification.PushNotificationMessage;
 import bisq.relay.notification.PushNotificationResult;
 import com.google.api.core.SettableApiFuture;
 import com.google.firebase.messaging.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 
 /**
  * Unit test for FcmPushNotificationSender - uses mocks, no Spring context needed.
  */
+@ExtendWith(MockitoExtension.class)
 class FcmPushNotificationSenderTest {
     private static final String DEVICE_TOKEN =
             "d4HedtovQCyRdgPsxM0JbA:APA91bFJIwRdBpO4SQpeSuA5rpEnu5N3Y3_c1T5x69gpedyKwGLUrApT6xkwIq8LZVPCy" +
                     "KVi1nh5NdG37TN2nGhpqchOUCysHweuL8V023WJYVwGgpUvdkk5mkYD9D3_QFj2c7f_2ul6";
 
+    @Mock
     private FirebaseMessaging firebaseMessaging;
     private FcmPushNotificationSender fcmSender;
 
@@ -54,18 +60,19 @@ class FcmPushNotificationSenderTest {
 
     @BeforeEach
     void setup() {
-        firebaseMessaging = mock(FirebaseMessaging.class);
-        fcmSender = new FcmPushNotificationSender(firebaseMessaging, new FcmPushNotificationBuilder());
+        givenSendDataOnlyIs(true);
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void whenPushNotificationIsAcceptedByFcm_thenSuccessfulResultReturned(final boolean urgent)
+    @CsvSource({"true,true", "true,false", "false,true", "false,false"})
+    void whenPushNotificationIsAcceptedByFcm_thenSuccessfulResultReturned(
+            final boolean urgent, final boolean sendDataOnly)
             throws IllegalAccessException, NoSuchFieldException {
 
+        givenSendDataOnlyIs(sendDataOnly);
         givenFcmWillAcceptPushNotifications();
         whenSendingAPushNotification(urgent);
-        thenTheSentPushNotificationIsCorrectlyPopulated(urgent);
+        thenTheSentPushNotificationIsCorrectlyPopulated(urgent, sendDataOnly);
         thenThePushNotificationWasAccepted();
 
         verifyNoMoreInteractions(firebaseMessaging);
@@ -76,6 +83,7 @@ class FcmPushNotificationSenderTest {
     void whenPushNotificationIsRejectedByFcm_thenErrorResultReturned(
             final String rejectionReason, final boolean isUnregistered)
             throws NoSuchFieldException, IllegalAccessException {
+
         givenFcmWillRejectPushNotifications(rejectionReason);
         whenSendingAPushNotification(true);
         thenTheSentPushNotificationIsCorrectlyPopulated(true);
@@ -93,7 +101,7 @@ class FcmPushNotificationSenderTest {
         assertThat(thrown).isInstanceOf(CompletionException.class);
 
         verify(firebaseMessaging).sendAsync(any(Message.class));
-        assertTrue(thrown.getCause() instanceof IOException);
+        assertInstanceOf(IOException.class, thrown.getCause());
 
 
         verifyNoMoreInteractions(firebaseMessaging);
@@ -123,6 +131,13 @@ class FcmPushNotificationSenderTest {
         when(firebaseMessaging.sendAsync(isA(Message.class))).thenReturn(apiFuture);
     }
 
+    private void givenSendDataOnlyIs(final boolean sendDataOnly) {
+        FcmProperties properties = new FcmProperties();
+        properties.setSendDataOnly(sendDataOnly);
+        FcmPushNotificationBuilder fcmPushNotificationBuilder = new FcmPushNotificationBuilder(properties);
+        fcmSender = new FcmPushNotificationSender(firebaseMessaging, fcmPushNotificationBuilder);
+    }
+
     private void whenSendingAPushNotification(final boolean urgent) {
         PushNotificationMessage pushNotificationMessage = new PushNotificationMessage("foo", urgent);
         pushNotificationResult = fcmSender.sendNotification(pushNotificationMessage, DEVICE_TOKEN).join();
@@ -134,6 +149,11 @@ class FcmPushNotificationSenderTest {
 
     private void thenTheSentPushNotificationIsCorrectlyPopulated(final boolean urgent)
             throws NoSuchFieldException, IllegalAccessException {
+        thenTheSentPushNotificationIsCorrectlyPopulated(urgent, true);
+    }
+
+    private void thenTheSentPushNotificationIsCorrectlyPopulated(final boolean urgent, final boolean sendDataOnly)
+            throws NoSuchFieldException, IllegalAccessException {
         assertThat(MessageUtil.getMessageToken(sentPushNotification)).isEqualTo(DEVICE_TOKEN);
         assertThat(MessageUtil.getMessageData(sentPushNotification)).isEqualTo(Map.of("encrypted", "foo"));
 
@@ -144,9 +164,14 @@ class FcmPushNotificationSenderTest {
                 urgent ? AndroidConfig.Priority.HIGH.name().toLowerCase() : AndroidConfig.Priority.NORMAL.name().toLowerCase());
 
         Notification notification = MessageUtil.getMessageNotification(sentPushNotification);
-        assertThat(NotificationUtil.getTitle(notification)).isEqualTo("You have received a Bisq notification");
-        assertThat(NotificationUtil.getBody(notification)).isEqualTo("Click to decrypt");
-        assertThat(NotificationUtil.getImage(notification)).isNull();
+        if (sendDataOnly) {
+            assertThat(notification).isNull();
+        } else {
+            assertThat(notification).isNotNull();
+            assertThat(NotificationUtil.getTitle(notification)).isEqualTo("You have received a Bisq notification");
+            assertThat(NotificationUtil.getBody(notification)).isEqualTo("Click to decrypt");
+            assertThat(NotificationUtil.getImage(notification)).isNull();
+        }
     }
 
     private void thenThePushNotificationWasAccepted() {

--- a/src/test/java/com/google/firebase/messaging/NotificationUtil.java
+++ b/src/test/java/com/google/firebase/messaging/NotificationUtil.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 public final class NotificationUtil {
     private NotificationUtil() {
+        throw new AssertionError("This class must not be instantiated");
     }
 
     public static String getTitle(@Nonnull final Notification notification)


### PR DESCRIPTION
Sending FCM data only messages will allow the Android app to process/decrypt background messages as they are received, rather than only when clicked on.

Will need to wait before enabling this in production for an [updated version of the app](https://github.com/bisq-network/bisqremote_Android/releases/tag/1.3.2) to be released that supports data-only messages and installed by a majority of users.