### PR TITLE
Add application metrics with Grafana dashboards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Build the bootJar
+FROM gradle:7.6.3-jdk17 AS build
+WORKDIR /workspace
+COPY . .
+RUN gradle clean bootJar -x test
+
+# Copy the required files
+FROM eclipse-temurin:17-jre-jammy
+WORKDIR /app
+COPY --from=build /workspace/build/libs/bisq-relay-*.jar /app/bisq-relay.jar
+COPY apnsCertificate.production.p12 .
+COPY apnsCertificatePassword.txt .
+COPY fcmServiceAccountKey.json .
+
+# Expose application traffic port
+EXPOSE 8080
+# Expose management/actuator port for Prometheus
+EXPOSE 9400
+
+ENTRYPOINT ["java", "-jar", "/app/bisq-relay.jar"]

--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ There are two ways to clone it before it can be built:
 
 1. Use the --recursive option in the clone command:
 ```sh
-$ git clone --recursive  https://github.com/bisq-network/bisq-relay.git
+  git clone --recursive  https://github.com/bisq-network/bisq-relay.git
 ```
 
 2. Do a normal clone, and pull down the bisq repo dependency with two git submodule commands:
 ```sh
-$ git clone https://github.com/bisq-network/bisq-relay.git
-$ cd bisq-relay
-$ git submodule init
-$ git submodule update
+  git clone https://github.com/bisq-network/bisq-relay.git
+  cd bisq-relay
+  git submodule init
+  git submodule update
 ```
 
 ### Build the Project
 
 ```sh
-$ ./gradlew clean build
+  ./gradlew clean build
 ```
 
 ## Running the Service
@@ -65,12 +65,12 @@ In order to obtain the APNs certificate, the following will need to be done on m
 After building the project, a `bisq-relay` script will be generated at the root of the project.
 Run the script. If the necessary files as described above are located in the root folder, the service should start running.
 ```sh
-$ ./bisq-relay
+  ./bisq-relay
 ```
 
 If you need to specify a custom location/name of the files, you can provide arguments as follows:
 ```sh
-$ export BISQ_RELAY_OPTS="-Dfcm.firebaseConfigurationFile=serviceAccountKey.json -Dapns.certificateFile=apnsCert.production.p12 -Dapns.certificatePasswordFile=apnsCertPassword.txt"; ./bisq-relay
+  export BISQ_RELAY_OPTS="-Dfcm.firebaseConfigurationFile=serviceAccountKey.json -Dapns.certificateFile=apnsCert.production.p12 -Dapns.certificatePasswordFile=apnsCertPassword.txt"; ./bisq-relay
 ```
 
 ## Deploying a Local Test Environment

--- a/README.md
+++ b/README.md
@@ -72,3 +72,18 @@ If you need to specify a custom location/name of the files, you can provide argu
 ```sh
 $ export BISQ_RELAY_OPTS="-Dfcm.firebaseConfigurationFile=serviceAccountKey.json -Dapns.certificateFile=apnsCert.production.p12 -Dapns.certificatePasswordFile=apnsCertPassword.txt"; ./bisq-relay
 ```
+
+## Deploying a Local Test Environment
+
+Use the following docker command to deploy a complete local test environment:
+
+```sh
+  docker compose up --build
+```
+
+Once deployed, the following will be available:
+
+- Application REST API: http://127.0.0.1:8080 (e.g. `POST http://127.0.0.1:8080/v1/apns/device/{deviceToken}`)
+- Application management interface: http://127.0.0.1:9400 (e.g. http://127.0.0.1:9400/actuator/info)
+- Grafana: http://127.0.0.1:3000
+- Prometheus: http://127.0.0.1:9090

--- a/build.gradle
+++ b/build.gradle
@@ -59,11 +59,6 @@ dependencies {
     implementation libs.logback.core
     implementation libs.logback.classic
 
-    compileOnly libs.lombok
-    annotationProcessor libs.lombok
-    testAnnotationProcessor libs.lombok
-    testCompileOnly libs.lombok
-
     testImplementation libs.junit.jupiter
     testImplementation libs.spring.boot.test
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.shadow)
     alias(libs.plugins.springDependencyManagement)
     alias(libs.plugins.springframeworkBoot)
+    alias(libs.plugins.gradleGitProperties)
 }
 
 repositories {
@@ -49,6 +50,11 @@ dependencies {
     }
     implementation libs.pushy
 
+    implementation libs.spring.boot.actuator
+    runtimeOnly libs.micrometer.registry.prometheus
+
+    implementation libs.apache.commons.lang3
+
     implementation libs.slf4j.api
     implementation libs.logback.core
     implementation libs.logback.classic
@@ -60,6 +66,26 @@ dependencies {
 
     testImplementation libs.junit.jupiter
     testImplementation libs.spring.boot.test
+}
+
+/**
+ * Generate META-INF/build-info.properties at build time so /actuator/info shows build info.
+ */
+springBoot {
+    buildInfo {
+        properties {
+            name = project.name
+            version = project.version.toString()
+        }
+    }
+}
+
+/**
+ * Configure git-properties so /actuator/info shows git info.
+ */
+gitProperties {
+    keys = ['git.branch', 'git.commit.time', 'git.commit.id']
+    failOnNoGitDirectory = false
 }
 
 clean.doFirst {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  relay-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: bisq-relay:local
+    container_name: relay-app
+    ports:
+      - "8080:8080"   # application traffic
+      - "9400:9400"   # management/actuator port for Prometheus
+    healthcheck:
+      test: [ "CMD", "wget", "-qO-", "http://localhost:9400/actuator/health" ]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    entrypoint: [ "/bin/sh", "-c" ]
+    command:
+      - |
+        sed "s|localhost|relay-app|g" /tmp/prometheus.yaml > /etc/prometheus/prometheus.yaml &&
+        exec /bin/prometheus \
+          --config.file=/etc/prometheus/prometheus.yml \
+          --storage.tsdb.retention.time=7d \
+          --web.enable-lifecycle
+    volumes:
+      - ./monitoring/prometheus/prometheus.yaml:/tmp/prometheus.yaml:ro
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: "admin"
+      GF_SECURITY_ADMIN_PASSWORD: "admin"
+    entrypoint: [ "/bin/sh", "-c" ]
+    command:
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources &&
+        sed "s|localhost|prometheus|g" /tmp/datasources.yaml > /etc/grafana/provisioning/datasources/datasources.yaml &&
+        /run.sh
+    volumes:
+      - ./monitoring/grafana/provisioning/datasources/datasources.yaml:/tmp/datasources.yaml:ro
+      - ./monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    restart: unless-stopped

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@
 # when multiple versions are attempted to be brought in as transitive dependencies of other requirements.
 [versions]
 firebase-lib = { strictly = '9.2.0' }
+apache-commons-lib = { strictly = '3.18.0' }
 gradle-git-properties-plugin = { strictly = '2.5.2' }
 junit-jupiter-lib = { strictly = '5.10.2' }
 logback-lib = { strictly = '1.5.3' }
@@ -20,6 +21,7 @@ springframework-plugin = { strictly = '3.2.3' }
 # Note: keys can contain dash (protobuf-java) but the dash is replaced by dot when referenced
 # in a build.gradle ('implementation libs.protobuf.java')
 [libraries]
+apache-commons-lang3 = { module = 'org.apache.commons:commons-lang3', version.ref = 'apache-commons-lib' }
 firebase = { module = 'com.google.firebase:firebase-admin', version.ref = 'firebase-lib' }
 junit-jupiter = { module = 'org.junit.jupiter:junit-jupiter', version.ref = 'junit-jupiter-lib' }
 logback-core = { module = 'ch.qos.logback:logback-core', version.ref = 'logback-lib' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@
 # when multiple versions are attempted to be brought in as transitive dependencies of other requirements.
 [versions]
 firebase-lib = { strictly = '9.2.0' }
+gradle-git-properties-plugin = { strictly = '2.5.2' }
 junit-jupiter-lib = { strictly = '5.10.2' }
 logback-lib = { strictly = '1.5.3' }
 lombok-lib = { strictly = '1.18.30' }
@@ -24,9 +25,11 @@ junit-jupiter = { module = 'org.junit.jupiter:junit-jupiter', version.ref = 'jun
 logback-core = { module = 'ch.qos.logback:logback-core', version.ref = 'logback-lib' }
 logback-classic = { module = 'ch.qos.logback:logback-classic', version.ref = 'logback-lib' }
 lombok = { module = 'org.projectlombok:lombok', version.ref = 'lombok-lib' }
+micrometer-registry-prometheus = { module = 'io.micrometer:micrometer-registry-prometheus' }
 pushy = { module = 'com.eatthepath:pushy', version.ref = 'pushy-lib' }
 slf4j-api = { module = 'org.slf4j:slf4j-api', version.ref = 'slf4j-lib' }
 spring-boot-dependencies = { module = 'org.springframework.boot:spring-boot-dependencies', version.ref = 'spring-boot-lib' }
+spring-boot-actuator = { module = 'org.springframework.boot:spring-boot-starter-actuator', version.ref = 'spring-boot-lib' }
 spring-boot-web = { module = 'org.springframework.boot:spring-boot-starter-web', version.ref = 'spring-boot-lib' }
 spring-boot-validation = { module = 'org.springframework.boot:spring-boot-starter-validation', version.ref = 'spring-boot-lib' }
 spring-boot-test = { module = 'org.springframework.boot:spring-boot-starter-test', version.ref = 'spring-boot-lib' }
@@ -37,3 +40,4 @@ spring-boot-test = { module = 'org.springframework.boot:spring-boot-starter-test
 shadow = { id = 'com.github.johnrengelman.shadow', version.ref = 'shadow-plugin' }
 springDependencyManagement = { id = 'io.spring.dependency-management', version.ref = 'spring-plugin' }
 springframeworkBoot = { id = 'org.springframework.boot', version.ref = 'springframework-plugin' }
+gradleGitProperties = { id = 'com.gorylenko.gradle-git-properties', version.ref = 'gradle-git-properties-plugin' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ firebase-lib = { strictly = '9.6.0' }
 gradle-git-properties-plugin = { strictly = '2.5.2' }
 junit-jupiter-lib = { strictly = '5.13.4' }
 logback-lib = { strictly = '1.5.18' }
-lombok-lib = { strictly = '1.18.30' }
 pushy-lib = { strictly = '0.15.4' }
 slf4j-lib = { strictly = '2.0.17' }
 spring-boot-lib = { strictly = '3.5.6' }
@@ -26,7 +25,6 @@ firebase = { module = 'com.google.firebase:firebase-admin', version.ref = 'fireb
 junit-jupiter = { module = 'org.junit.jupiter:junit-jupiter', version.ref = 'junit-jupiter-lib' }
 logback-core = { module = 'ch.qos.logback:logback-core', version.ref = 'logback-lib' }
 logback-classic = { module = 'ch.qos.logback:logback-classic', version.ref = 'logback-lib' }
-lombok = { module = 'org.projectlombok:lombok', version.ref = 'lombok-lib' }
 micrometer-registry-prometheus = { module = 'io.micrometer:micrometer-registry-prometheus' }
 pushy = { module = 'com.eatthepath:pushy', version.ref = 'pushy-lib' }
 slf4j-api = { module = 'org.slf4j:slf4j-api', version.ref = 'slf4j-lib' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,18 +4,18 @@
 # Convention: mark all versions using 'strictly'. This ensures only one version is allowed in the dependency tree, even
 # when multiple versions are attempted to be brought in as transitive dependencies of other requirements.
 [versions]
-firebase-lib = { strictly = '9.2.0' }
 apache-commons-lib = { strictly = '3.18.0' }
+firebase-lib = { strictly = '9.6.0' }
 gradle-git-properties-plugin = { strictly = '2.5.2' }
-junit-jupiter-lib = { strictly = '5.10.2' }
-logback-lib = { strictly = '1.5.3' }
+junit-jupiter-lib = { strictly = '5.13.4' }
+logback-lib = { strictly = '1.5.18' }
 lombok-lib = { strictly = '1.18.30' }
 pushy-lib = { strictly = '0.15.4' }
-slf4j-lib = { strictly = '2.0.12' }
-spring-boot-lib = { strictly = '3.2.3' }
+slf4j-lib = { strictly = '2.0.17' }
+spring-boot-lib = { strictly = '3.5.6' }
 shadow-plugin = { strictly = '7.1.2' }
-spring-plugin = { strictly = '1.1.4' }
-springframework-plugin = { strictly = '3.2.3' }
+spring-plugin = { strictly = '1.1.7' }
+springframework-plugin = { strictly = '3.3.13' }
 
 # Referenced in subproject's build.gradle > dependencies block in the form 'implementation libs.guava'
 # Note: keys can contain dash (protobuf-java) but the dash is replaced by dot when referenced

--- a/monitoring/grafana/dashboards/bisq-relay-http.json
+++ b/monitoring/grafana/dashboards/bisq-relay-http.json
@@ -1,0 +1,128 @@
+{
+  "title": "Bisq Relay – HTTP",
+  "uid": "bisq-relay-http",
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "tags": [
+    "http"
+  ],
+  "refresh": "10s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "uri",
+        "type": "query",
+        "label": "URI",
+        "datasource": null,
+        "refresh": 2,
+        "query": "label_values(http_server_requests_seconds_count, uri)",
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "__all"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Request Rate by URI",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 16,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_count{uri!~\"/actuator.*\",uri=~\"$uri\"}[5m]))",
+          "legendFormat": "{{uri}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps",
+          "decimals": 2
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Request Rate by Status",
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 16,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(http_server_requests_seconds_count{uri!~\"/actuator.*\",uri=~\"$uri\"}[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps",
+          "decimals": 2
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency Percentiles",
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 16,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(http_server_requests_seconds_bucket{uri!~\"/actuator.*\",uri=~\"$uri\"}[5m])))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(http_server_requests_seconds_bucket{uri!~\"/actuator.*\",uri=~\"$uri\"}[5m])))",
+          "legendFormat": "p90"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{uri!~\"/actuator.*\",uri=~\"$uri\"}[5m])))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_requests_seconds_bucket{uri!~\"/actuator.*\",uri=~\"$uri\"}[5m])))",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 2
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/bisq-relay-jvm.json
+++ b/monitoring/grafana/dashboards/bisq-relay-jvm.json
@@ -1,0 +1,200 @@
+{
+  "title": "Bisq Relay – JVM",
+  "uid": "bisq-relay-jvm",
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "tags": [
+    "jvm"
+  ],
+  "refresh": "10s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Uptime",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "process_uptime_seconds"
+        }
+      ],
+      "options": {
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU Usage",
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 16,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "process_cpu_usage",
+          "legendFormat": "process"
+        },
+        {
+          "expr": "system_cpu_usage",
+          "legendFormat": "system"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Threads",
+      "gridPos": {
+        "x": 0,
+        "y": 12,
+        "w": 16,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "jvm_threads_live_threads",
+          "legendFormat": "live"
+        },
+        {
+          "expr": "jvm_threads_peak_threads",
+          "legendFormat": "peak"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Heap Memory Usage",
+      "gridPos": {
+        "x": 0,
+        "y": 20,
+        "w": 16,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (area) (jvm_memory_used_bytes{area=\"heap\"})",
+          "legendFormat": "used"
+        },
+        {
+          "expr": "sum by (area) (jvm_memory_max_bytes{area=\"heap\"})",
+          "legendFormat": "max"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "GC Allocated / Promoted (per second)",
+      "gridPos": {
+        "x": 0,
+        "y": 28,
+        "w": 16,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "rate(jvm_gc_memory_allocated_bytes_total[5m])",
+          "legendFormat": "allocated"
+        },
+        {
+          "expr": "rate(jvm_gc_memory_promoted_bytes_total[5m])",
+          "legendFormat": "promoted"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "GC Pause",
+      "gridPos": {
+        "x": 0,
+        "y": 36,
+        "w": 16,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "1000 * sum by (gc, cause, action) (rate(jvm_gc_pause_seconds_sum[5m]) / rate(jvm_gc_pause_seconds_count[5m]))",
+          "legendFormat": "average"
+        },
+        {
+          "expr": "1000 * max_over_time(jvm_gc_pause_seconds_max[5m])",
+          "legendFormat": "max"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms"
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/bisq-relay-push.json
+++ b/monitoring/grafana/dashboards/bisq-relay-push.json
@@ -1,0 +1,276 @@
+{
+  "title": "Bisq Relay – Push Notifications",
+  "uid": "bisq-relay-push",
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "tags": [
+    "push"
+  ],
+  "refresh": "10s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "provider",
+        "type": "query",
+        "label": "Provider",
+        "datasource": null,
+        "refresh": 2,
+        "query": "label_values(push_total, provider)",
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "__all"
+        }
+      },
+      {
+        "name": "result",
+        "type": "query",
+        "label": "Result",
+        "datasource": null,
+        "refresh": 2,
+        "query": "label_values(push_total, result)",
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "__all"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Attempt Rate",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(push_attempts_total{provider=~\"$provider\"}[5m]))",
+          "legendFormat": "{{$provider}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps",
+          "decimals": 2
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Accept Rate",
+      "gridPos": {
+        "x": 4,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(push_total{provider=~\"$provider\",result=\"accepted\"}[5m])) / clamp_min(sum(rate(push_total{provider=~\"$provider\"}[5m])), 1e-9)",
+          "legendFormat": "{{provider}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps",
+          "decimals": 2
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Error Rate",
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(push_total{provider=~\"$provider\",result=\"error\"}[5m])) / clamp_min(sum(rate(push_attempts_total{provider=~\"$provider\"}[5m])), 1e-9)",
+          "legendFormat": "{{$provider}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Delivery Outcome",
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum by (result, provider) (rate(push_total{provider=~\"$provider\"}[5m]))",
+          "legendFormat": "{{provider}} {{result}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps",
+          "decimals": 2
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency Percentiles (accepted)",
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le, provider) (rate(push_latency_seconds_bucket{provider=~\"$provider\",result=\"accepted\"}[5m])))",
+          "legendFormat": "p50 {{provider}}"
+        },
+        {
+          "expr": "histogram_quantile(0.9, sum by (le, provider) (rate(push_latency_seconds_bucket{provider=~\"$provider\",result=\"accepted\"}[5m])))",
+          "legendFormat": "p90 {{provider}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, provider) (rate(push_latency_seconds_bucket{provider=~\"$provider\",result=\"accepted\"}[5m])))",
+          "legendFormat": "p95 {{provider}}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, provider) (rate(push_latency_seconds_bucket{provider=~\"$provider\",result=\"accepted\"}[5m])))",
+          "legendFormat": "p99 {{provider}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 2
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Rejected/Error by Code",
+      "description": "Aggregated by classification tag `code` (token, throttle, payload, server, auth, io, other).",
+      "gridPos": {
+        "x": 12,
+        "y": 4,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (code) (rate(push_latency_seconds_count{provider=~\"$provider\",result!=\"accepted\"}[5m]))",
+          "legendFormat": "{{code}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps",
+          "decimals": 2
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "table",
+      "title": "Top Error Codes (5m avg)",
+      "gridPos": {
+        "x": 0,
+        "y": 12,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (code) (rate(push_latency_seconds_count{provider=~\"$provider\",result=\"error\"}[5m])))",
+          "legendFormat": "{{code}}"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Throughput: Attempts vs Accepted",
+      "gridPos": {
+        "x": 12,
+        "y": 12,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(push_attempts_total{provider=~\"$provider\"}[5m]))",
+          "legendFormat": "attempts"
+        },
+        {
+          "expr": "sum(rate(push_total{provider=~\"$provider\",result=\"accepted\"}[5m]))",
+          "legendFormat": "accepted"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rps",
+          "decimals": 2
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "all"
+        }
+      }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yaml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'Bisq Relay'
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/monitoring/grafana/provisioning/datasources/datasources.yaml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://localhost:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: 10s

--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 10s
+  scrape_timeout: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: "bisq-relay"
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - "localhost:9400"
+    relabel_configs:
+      - target_label: service
+        replacement: relay

--- a/src/main/java/bisq/relay/notification/PushNotificationMessage.java
+++ b/src/main/java/bisq/relay/notification/PushNotificationMessage.java
@@ -19,9 +19,19 @@ package bisq.relay.notification;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.annotation.Nullable;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record PushNotificationMessage(
         @Nullable String encrypted,
         boolean isUrgent) {
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("encrypted", encrypted)
+                .append("isUrgent", isUrgent)
+                .toString();
+    }
 }

--- a/src/main/java/bisq/relay/notification/apns/ApnsPushNotificationController.java
+++ b/src/main/java/bisq/relay/notification/apns/ApnsPushNotificationController.java
@@ -19,12 +19,14 @@ package bisq.relay.notification.apns;
 
 import bisq.relay.notification.PushNotificationController;
 import bisq.relay.notification.PushNotificationMessage;
+import bisq.relay.notification.PushNotificationSender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,9 +44,9 @@ public class ApnsPushNotificationController extends PushNotificationController {
 
     @Autowired
     public ApnsPushNotificationController(
-            final ApnsPushNotificationSender apnsSender,
+            @Qualifier("apnsPushNotificationSender") final PushNotificationSender sender,
             final ObjectMapper objectMapper) {
-        super(apnsSender, objectMapper);
+        super(sender, objectMapper);
     }
 
     @PostMapping(value = "/v1/apns/device/{deviceToken}")

--- a/src/main/java/bisq/relay/notification/apns/ApnsPushNotificationSender.java
+++ b/src/main/java/bisq/relay/notification/apns/ApnsPushNotificationSender.java
@@ -20,6 +20,7 @@ package bisq.relay.notification.apns;
 import bisq.relay.notification.PushNotificationMessage;
 import bisq.relay.notification.PushNotificationResult;
 import bisq.relay.notification.PushNotificationSender;
+import bisq.relay.notification.metrics.PushProvider;
 import com.eatthepath.pushy.apns.ApnsClient;
 import com.eatthepath.pushy.apns.ApnsClientBuilder;
 import com.eatthepath.pushy.apns.PushNotificationResponse;
@@ -41,6 +42,9 @@ import java.util.Objects;
 import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
 
+import static bisq.relay.notification.metrics.PushMetrics.PROVIDER_ID_APNS;
+
+@PushProvider(PROVIDER_ID_APNS)
 @Service
 public class ApnsPushNotificationSender implements PushNotificationSender {
     private static final Logger LOG = LoggerFactory.getLogger(ApnsPushNotificationSender.class);
@@ -66,8 +70,10 @@ public class ApnsPushNotificationSender implements PushNotificationSender {
 
         final File appleCertFile = new File(apnsCertificateFile);
 
-        apnsClient = new ApnsClientBuilder().setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
-                .setClientCredentials(appleCertFile, appleCertPassword).build();
+        apnsClient = new ApnsClientBuilder()
+                .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
+                .setClientCredentials(appleCertFile, appleCertPassword)
+                .build();
 
         LOG.info("APNS client is ready to push notifications");
     }
@@ -90,6 +96,7 @@ public class ApnsPushNotificationSender implements PushNotificationSender {
 
     // TODO implement circuit breaker, can use resilience4j
     //  Ref: https://www.baeldung.com/spring-boot-resilience4j
+    @Override
     public CompletableFuture<PushNotificationResult> sendNotification(
             @Nonnull final PushNotificationMessage pushNotificationMessage,
             @Nonnull final String deviceToken) {

--- a/src/main/java/bisq/relay/notification/fcm/FcmPushNotificationController.java
+++ b/src/main/java/bisq/relay/notification/fcm/FcmPushNotificationController.java
@@ -19,12 +19,14 @@ package bisq.relay.notification.fcm;
 
 import bisq.relay.notification.PushNotificationController;
 import bisq.relay.notification.PushNotificationMessage;
+import bisq.relay.notification.PushNotificationSender;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,9 +44,9 @@ public class FcmPushNotificationController extends PushNotificationController {
 
     @Autowired
     public FcmPushNotificationController(
-            final FcmPushNotificationSender fcmSender,
+            @Qualifier("fcmPushNotificationSender") final PushNotificationSender sender,
             final ObjectMapper objectMapper) {
-        super(fcmSender, objectMapper);
+        super(sender, objectMapper);
     }
 
     @PostMapping(value = "/v1/fcm/device/{deviceToken}")

--- a/src/main/java/bisq/relay/notification/fcm/FcmPushNotificationSender.java
+++ b/src/main/java/bisq/relay/notification/fcm/FcmPushNotificationSender.java
@@ -20,6 +20,7 @@ package bisq.relay.notification.fcm;
 import bisq.relay.notification.PushNotificationMessage;
 import bisq.relay.notification.PushNotificationResult;
 import bisq.relay.notification.PushNotificationSender;
+import bisq.relay.notification.metrics.PushProvider;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
@@ -47,6 +48,9 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+import static bisq.relay.notification.metrics.PushMetrics.PROVIDER_ID_FCM;
+
+@PushProvider(PROVIDER_ID_FCM)
 @Service
 public class FcmPushNotificationSender implements PushNotificationSender {
     private static final Logger LOG = LoggerFactory.getLogger(FcmPushNotificationSender.class);
@@ -98,6 +102,7 @@ public class FcmPushNotificationSender implements PushNotificationSender {
 
     // TODO implement circuit breaker, can use resilience4j
     //  Ref: https://www.baeldung.com/spring-boot-resilience4j
+    @Override
     public CompletableFuture<PushNotificationResult> sendNotification(
             @Nonnull final PushNotificationMessage pushNotificationMessage,
             @Nonnull final String deviceToken) {

--- a/src/main/java/bisq/relay/notification/metrics/MetricsPushNotificationSender.java
+++ b/src/main/java/bisq/relay/notification/metrics/MetricsPushNotificationSender.java
@@ -1,0 +1,160 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.relay.notification.metrics;
+
+import bisq.relay.notification.PushNotificationMessage;
+import bisq.relay.notification.PushNotificationResult;
+import bisq.relay.notification.PushNotificationSender;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static bisq.relay.notification.metrics.PushMetrics.*;
+
+/**
+ * Decorator that adds Micrometer metrics to any {@link PushNotificationSender}.
+ * <p>Emits the following metrics:
+ * <ul>
+ *   <li>{@code push_attempts_total{provider}}</li>
+ *   <li>{@code push_total{provider,result=accepted|rejected|error}}</li>
+ *   <li>{@code push_latency_seconds_bucket{provider,result,code,le=...}}</li>
+ * </ul>
+ * <p><strong>Note:</strong> The {@link MeterRegistry} is resolved lazily via {@link ObjectProvider}
+ * to avoid early bean initialization during post-processing. If no registry is available, this
+ * decorator becomes a no-op and simply delegates for the {@link PushNotificationSender}.
+ */
+final class MetricsPushNotificationSender implements PushNotificationSender {
+
+    private static final double[] PUSH_LATENCY_PERCENTILES = {0.5, 0.9, 0.95, 0.99};
+    private static final Duration PUSH_LATENCY_MAX_EXPECTED_DURATION = Duration.ofSeconds(10);
+
+    private final String providerId;
+    private final PushNotificationSender pushNotificationSender;
+    private final ObjectProvider<MeterRegistry> registryProvider;
+
+    /**
+     * Creates a metrics-decorated push notification sender.
+     *
+     * @param providerId             provider id (e.g., {@link PushMetrics#PROVIDER_ID_APNS}, {@link PushMetrics#PROVIDER_ID_FCM})
+     * @param pushNotificationSender underlying push notification sender to delegate for
+     * @param registryProvider       lazy provider for {@link MeterRegistry}; may yield {@code null} at runtime
+     */
+    public MetricsPushNotificationSender(
+            @Nonnull final String providerId,
+            @Nonnull final PushNotificationSender pushNotificationSender,
+            @Nonnull final ObjectProvider<MeterRegistry> registryProvider) {
+        this.providerId = Objects.requireNonNull(providerId, "providerId must not be null");
+        this.pushNotificationSender = Objects.requireNonNull(pushNotificationSender, "pushNotificationSender must not be null");
+        this.registryProvider = Objects.requireNonNull(registryProvider, "registryProvider must not be null");
+    }
+
+    @Override
+    public CompletableFuture<PushNotificationResult> sendNotification(
+            @Nonnull final PushNotificationMessage message,
+            @Nonnull final String deviceToken) {
+
+        // Resolve registry lazily and tolerate absence (e.g., in certain tests)
+        final MeterRegistry registry = registryProvider.getIfAvailable();
+
+        final long startNanos = System.nanoTime();
+
+        if (registry != null) {
+            // Count the attempt (low cardinality: only provider tag)
+            registry.counter(METRIC_PUSH_ATTEMPTS_TOTAL, TAG_PROVIDER, providerId).increment();
+        }
+
+        return pushNotificationSender.sendNotification(message, deviceToken)
+                .whenComplete((result, error) -> {
+                    if (registry == null) {
+                        // No metrics backend available; nothing to record
+                        return;
+                    }
+
+                    final String outcome;
+                    final String code;
+
+                    if (error != null) {
+                        outcome = RESULT_ERROR;
+                        code = CODE_IO;
+                    } else if (result != null && result.wasAccepted()) {
+                        outcome = RESULT_ACCEPTED;
+                        code = CODE_NONE;
+                    } else {
+                        outcome = RESULT_REJECTED;
+                        code = classifyCode(providerId, result != null ? result.errorCode() : null);
+                    }
+
+                    // Count the result (providerId + outcome)
+                    registry.counter(METRIC_PUSH_TOTAL,
+                            TAG_PROVIDER, providerId,
+                            TAG_RESULT, outcome).increment();
+
+                    // Record the latency (providerId, outcome, code)
+                    final long durationNanos = System.nanoTime() - startNanos;
+                    Timer.builder(METRIC_PUSH_LATENCY_SECONDS)
+                            .tags(TAG_PROVIDER, providerId, TAG_RESULT, outcome, TAG_CODE, code)
+                            .publishPercentiles(PUSH_LATENCY_PERCENTILES)
+                            .maximumExpectedValue(PUSH_LATENCY_MAX_EXPECTED_DURATION)
+                            .register(registry)
+                            .record(durationNanos, TimeUnit.NANOSECONDS);
+                });
+    }
+
+    /**
+     * Maps raw provider error codes into a bounded set of tag values from {@link PushMetrics}.
+     *
+     * @param providerId the provider id (e.g., {@link PushMetrics#PROVIDER_ID_APNS}, {@link PushMetrics#PROVIDER_ID_FCM})
+     * @param errorCode  the raw error code returned by the provider
+     * @return a low-cardinality classification tag value
+     */
+    private static String classifyCode(@Nonnull final String providerId, @Nullable final String errorCode) {
+        if (errorCode == null) {
+            return CODE_OTHER;
+        }
+
+        if (PROVIDER_ID_APNS.equals(providerId)) {
+            return switch (errorCode) {
+                case "Unregistered", "BadDeviceToken" -> CODE_TOKEN;
+                case "TooManyRequests" -> CODE_THROTTLE;
+                case "PayloadTooLarge" -> CODE_PAYLOAD;
+                case "InternalServerError", "ServiceUnavailable" -> CODE_SERVER;
+                default -> CODE_OTHER;
+            };
+        }
+
+        if (PROVIDER_ID_FCM.equals(providerId)) {
+            return switch (errorCode) {
+                case "UNREGISTERED", "INVALID_ARGUMENT" -> CODE_TOKEN;
+                case "QUOTA_EXCEEDED" -> CODE_THROTTLE;
+                case "MESSAGE_TOO_BIG" -> CODE_PAYLOAD;
+                case "UNAVAILABLE", "INTERNAL" -> CODE_SERVER;
+                case "SENDER_ID_MISMATCH" -> CODE_AUTH;
+                default -> CODE_OTHER;
+            };
+        }
+
+        return CODE_OTHER;
+    }
+}

--- a/src/main/java/bisq/relay/notification/metrics/MetricsWrappingConfiguration.java
+++ b/src/main/java/bisq/relay/notification/metrics/MetricsWrappingConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.relay.notification.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+/**
+ * Infrastructure config that registers the metrics wrapper as a BeanPostProcessor.
+ * Declared with the lowest precedence to let other post-processors/proxies run first.
+ */
+@Configuration
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+class MetricsWrappingConfiguration {
+
+    @Bean
+    @Order(Ordered.LOWEST_PRECEDENCE)
+    PushMetricsAutoWrapper pushMetricsAutoWrapper(ObjectProvider<MeterRegistry> registryProvider) {
+        return new PushMetricsAutoWrapper(registryProvider);
+    }
+}

--- a/src/main/java/bisq/relay/notification/metrics/PushMetrics.java
+++ b/src/main/java/bisq/relay/notification/metrics/PushMetrics.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.relay.notification.metrics;
+
+/**
+ * Constants for push notification metrics and provider IDs.
+ * <p>
+ * Defines metric names, tag keys, tag values, provider IDs, and classification categories.
+ */
+public final class PushMetrics {
+
+    private PushMetrics() {
+        throw new AssertionError("This class must not be instantiated");
+    }
+
+    // ========================================================================
+    // Provider IDs
+    // ========================================================================
+
+    public static final String PROVIDER_ID_APNS = "apns";
+    public static final String PROVIDER_ID_FCM = "fcm";
+
+    // ========================================================================
+    // Metric names
+    // ========================================================================
+
+    /**
+     * Counter for push notification attempts, tagged by provider.
+     */
+    public static final String METRIC_PUSH_ATTEMPTS_TOTAL = "push_attempts_total";
+
+    /**
+     * Counter for completed sends, tagged by provider and result.
+     */
+    public static final String METRIC_PUSH_TOTAL = "push_total";
+
+    /**
+     * Histogram of send latencies in seconds, tagged by provider, result, and code.
+     */
+    public static final String METRIC_PUSH_LATENCY_SECONDS = "push_latency_seconds";
+
+    // ========================================================================
+    // Tag keys
+    // ========================================================================
+
+    public static final String TAG_PROVIDER = "provider";
+    public static final String TAG_RESULT = "result";
+    public static final String TAG_CODE = "code";
+
+    // ========================================================================
+    // Tag values: result
+    // ========================================================================
+
+    /**
+     * Result: push accepted by the provider.
+     */
+    public static final String RESULT_ACCEPTED = "accepted";
+
+    /**
+     * Result: push rejected by the provider.
+     */
+    public static final String RESULT_REJECTED = "rejected";
+
+    /**
+     * Result: push failed before receiving a provider response.
+     */
+    public static final String RESULT_ERROR = "error";
+
+    // ========================================================================
+    // Tag values: code classification
+    // ========================================================================
+
+    /**
+     * No error code (used for accepted pushes).
+     */
+    public static final String CODE_NONE = "none";
+
+    /**
+     * Token-related problem (invalid, unregistered, mismatched).
+     */
+    public static final String CODE_TOKEN = "token";
+
+    /**
+     * Payload too large or invalid in size.
+     */
+    public static final String CODE_PAYLOAD = "payload";
+
+    /**
+     * Provider throttling requests.
+     */
+    public static final String CODE_THROTTLE = "throttle";
+
+    /**
+     * Server-side error at the provider.
+     */
+    public static final String CODE_SERVER = "server";
+
+    /**
+     * Authentication/authorization problem.
+     */
+    public static final String CODE_AUTH = "auth";
+
+    /**
+     * I/O or network-level failure before provider response.
+     */
+    public static final String CODE_IO = "io";
+
+    /**
+     * Unclassified or unexpected error.
+     */
+    public static final String CODE_OTHER = "other";
+}

--- a/src/main/java/bisq/relay/notification/metrics/PushMetricsAutoWrapper.java
+++ b/src/main/java/bisq/relay/notification/metrics/PushMetricsAutoWrapper.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.relay.notification.metrics;
+
+import bisq.relay.notification.PushNotificationSender;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.Nonnull;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+/**
+ * Auto-wraps all {@link PushNotificationSender} beans with {@link MetricsPushNotificationSender}
+ * to emit standardized metrics.
+ */
+class PushMetricsAutoWrapper implements BeanPostProcessor {
+
+    private final ObjectProvider<MeterRegistry> registryProvider;
+
+    public PushMetricsAutoWrapper(ObjectProvider<MeterRegistry> registryProvider) {
+        // Do NOT resolve here; keep it lazy
+        this.registryProvider = registryProvider;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(
+            @Nonnull final Object bean,
+            @Nonnull final String beanName) throws BeansException {
+
+        if (bean instanceof MetricsPushNotificationSender) {
+            // Avoid double wrapping
+            return bean;
+        }
+
+        if (bean instanceof PushNotificationSender sender) {
+            final PushProvider ann = bean.getClass().getAnnotation(PushProvider.class);
+            if (ann == null || ann.value().isBlank()) {
+                throw new BeanInitializationException(
+                        "PushNotificationSender bean '" + beanName + "' (" + bean.getClass().getName() + ") " +
+                                "must be annotated with @PushProvider(\"<providerId>\") and providerId must be non-blank.");
+            }
+            String providerId = ann.value().trim();
+
+            return new MetricsPushNotificationSender(providerId, sender, registryProvider);
+        }
+
+        return bean;
+    }
+}

--- a/src/main/java/bisq/relay/notification/metrics/PushProvider.java
+++ b/src/main/java/bisq/relay/notification/metrics/PushProvider.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.relay.notification.metrics;
+
+import bisq.relay.notification.PushNotificationSender;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marks a {@link PushNotificationSender} implementation with the provider identifier for metrics tagging
+ * and automatic decoration.
+ *
+ * <p>Example:</p>
+ * <pre>{@code
+ * @Service
+ * @PushProvider(PushMetrics.PROVIDER_FCM)
+ * public class FcmPushNotificationSender implements PushNotificationSender {
+ *     ...
+ * }
+ * }</pre>
+ * <p>
+ * Typical values: {@value PushMetrics#PROVIDER_ID_APNS}, {@value PushMetrics#PROVIDER_ID_FCM}.
+ */
+@Documented
+@Target(TYPE)
+@Retention(RUNTIME)
+public @interface PushProvider {
+    /**
+     * The provider name to use for metrics tagging and bean decoration.
+     */
+    String value();
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,35 @@
+#########################################################################################
+## Server configuration
+#########################################################################################
+server.address=0.0.0.0
 server.port=8080
-
-fcm.firebaseUrl=https://bisqnotifications.firebaseio.com
+#########################################################################################
+## FCM configuration
+#########################################################################################
 fcm.firebaseConfigurationFile=fcmServiceAccountKey.json
-
+fcm.firebaseUrl=https://bisqnotifications.firebaseio.com
+#########################################################################################
+## APNs configuration
+#########################################################################################
 apns.bundleId=bisqremote.joachimneumann.com
 apns.certificateFile=apnsCertificate.production.p12
 apns.certificatePasswordFile=apnsCertificatePassword.txt
+#########################################################################################
+## Actuator/management configuration
+#########################################################################################
+management.server.address=0.0.0.0
+management.server.port=9400
+management.endpoint.prometheus.enabled=true
+management.endpoint.health.show-details=never
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoints.web.base-path=/actuator
+management.metrics.tags.app=bisq-relay
+management.metrics.tags.service=relay
+# HTTP server
+management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.distribution.percentiles.http.server.requests=0.5,0.9,0.95,0.99
+management.metrics.distribution.slo.http.server.requests=50ms,100ms,250ms,500ms,1s,2s,5s,10s
+# Push latency
+management.metrics.distribution.percentiles-histogram.push_latency_seconds=true
+management.metrics.distribution.percentiles.push_latency_seconds=0.5,0.9,0.95,0.99
+management.metrics.distribution.slo.push_latency_seconds=50ms,100ms,250ms,500ms,1s,2s,5s,10s

--- a/src/test/java/bisq/relay/RelayControllerTest.java
+++ b/src/test/java/bisq/relay/RelayControllerTest.java
@@ -22,7 +22,6 @@ import bisq.relay.notification.PushNotificationMessage;
 import bisq.relay.notification.PushNotificationResult;
 import bisq.relay.notification.apns.ApnsPushNotificationSender;
 import bisq.relay.notification.fcm.FcmPushNotificationSender;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.binary.Hex;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +38,6 @@ import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/bisq/relay/notification/metrics/MetricsPushNotificationSenderTest.java
+++ b/src/test/java/bisq/relay/notification/metrics/MetricsPushNotificationSenderTest.java
@@ -1,0 +1,171 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.relay.notification.metrics;
+
+import bisq.relay.notification.PushNotificationMessage;
+import bisq.relay.notification.PushNotificationResult;
+import bisq.relay.notification.PushNotificationSender;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.annotation.Nonnull;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import static bisq.relay.notification.metrics.PushMetrics.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetricsPushNotificationSenderTest {
+
+    private static final PushNotificationMessage MSG = new PushNotificationMessage("foo", true);
+
+    private static ObjectProvider<MeterRegistry> providerOf(@Nonnull final MeterRegistry registry) {
+        return new ObjectProvider<>() {
+            @Override
+            @Nonnull
+            public MeterRegistry getObject() {
+                return registry;
+            }
+
+            @Override
+            @Nonnull
+            public MeterRegistry getObject(@Nonnull final Object... args) {
+                return registry;
+            }
+
+            @Override
+            @Nonnull
+            public MeterRegistry getIfAvailable() {
+                return registry;
+            }
+
+            @Override
+            @Nonnull
+            public MeterRegistry getIfUnique() {
+                return registry;
+            }
+
+            @Override
+            @Nonnull
+            public Stream<MeterRegistry> orderedStream() {
+                return Stream.of(registry);
+            }
+
+            @Override
+            @Nonnull
+            public Stream<MeterRegistry> stream() {
+                return Stream.of(registry);
+            }
+        };
+    }
+
+    private final MeterRegistry registry = new SimpleMeterRegistry();
+
+    @ParameterizedTest
+    @ValueSource(strings = {PROVIDER_ID_APNS, PROVIDER_ID_FCM})
+    void whenPushNotificationAccepted_thenAcceptedMetricsRecorded(final String providerId) {
+        PushNotificationSender senderThatReturnsSuccessfulResponse = (m, tok) ->
+                CompletableFuture.completedFuture(
+                        new PushNotificationResult(true, null, null, false));
+
+        MetricsPushNotificationSender metricsSender = new MetricsPushNotificationSender(
+                providerId, senderThatReturnsSuccessfulResponse, providerOf(registry));
+
+        metricsSender.sendNotification(MSG, "tok").join();
+
+        assertThat(registry.get(METRIC_PUSH_ATTEMPTS_TOTAL).tag(TAG_PROVIDER, providerId).counter().count())
+                .describedAs(METRIC_PUSH_ATTEMPTS_TOTAL)
+                .isEqualTo(1.0);
+        assertThat(registry.get(METRIC_PUSH_TOTAL)
+                .tags(TAG_PROVIDER, providerId, TAG_RESULT, RESULT_ACCEPTED)
+                .counter().count())
+                .describedAs(String.format("%s{%s,%s}", METRIC_PUSH_TOTAL, providerId, RESULT_ACCEPTED))
+                .isEqualTo(1.0);
+        assertThat(registry.get(METRIC_PUSH_LATENCY_SECONDS)
+                .tags(TAG_PROVIDER, providerId, TAG_RESULT, RESULT_ACCEPTED, TAG_CODE, CODE_NONE)
+                .timer().count())
+                .describedAs(String.format("%s{%s,%s,%s}", METRIC_PUSH_LATENCY_SECONDS, providerId, RESULT_ACCEPTED, CODE_NONE))
+                .isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideProviderIdAndTokenErrorCode")
+    void whenPushNotificationRejected_thenRejectedMetricsRecorded(final String providerId, final String errorCode) {
+        PushNotificationSender senderThatReturnsTokenError = (m, tok) ->
+                CompletableFuture.completedFuture(
+                        new PushNotificationResult(false, errorCode, "msg", true));
+
+        MetricsPushNotificationSender metricsSender = new MetricsPushNotificationSender(
+                providerId, senderThatReturnsTokenError, providerOf(registry));
+
+        metricsSender.sendNotification(MSG, "tok").join();
+
+        assertThat(registry.get(METRIC_PUSH_TOTAL)
+                .tags(TAG_PROVIDER, providerId, TAG_RESULT, RESULT_REJECTED)
+                .counter().count())
+                .describedAs(String.format("%s{%s,%s}", METRIC_PUSH_TOTAL, providerId, RESULT_REJECTED))
+                .isEqualTo(1.0);
+        assertThat(registry.get(METRIC_PUSH_LATENCY_SECONDS)
+                .tags(TAG_PROVIDER, providerId, TAG_RESULT, RESULT_REJECTED, TAG_CODE, CODE_TOKEN)
+                .timer().count())
+                .describedAs(String.format("%s{%s,%s,%s}", METRIC_PUSH_LATENCY_SECONDS, providerId, RESULT_REJECTED, CODE_TOKEN))
+                .isEqualTo(1);
+    }
+
+    private static Stream<Arguments> provideProviderIdAndTokenErrorCode() {
+        return Stream.of(
+                Arguments.of(PROVIDER_ID_APNS, "BadDeviceToken"),
+                Arguments.of(PROVIDER_ID_FCM, "UNREGISTERED")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {PROVIDER_ID_APNS, PROVIDER_ID_FCM})
+    void whenPushNotificationError_thenErrorMetricsRecorded(final String providerId) {
+        PushNotificationSender senderThatThrowsException = (m, tok) -> {
+            var cf = new CompletableFuture<PushNotificationResult>();
+            cf.completeExceptionally(new RuntimeException("boom"));
+            return cf;
+        };
+
+        MetricsPushNotificationSender metricsSender = new MetricsPushNotificationSender(
+                providerId, senderThatThrowsException, providerOf(registry));
+
+        try {
+            metricsSender.sendNotification(MSG, "tok").join();
+        } catch (Exception ignored) {
+            // ignored
+        }
+
+        assertThat(registry.get(METRIC_PUSH_TOTAL)
+                .tags(TAG_PROVIDER, providerId, TAG_RESULT, RESULT_ERROR)
+                .counter().count())
+                .describedAs(String.format("%s{%s,%s}", METRIC_PUSH_TOTAL, providerId, RESULT_ERROR))
+                .isEqualTo(1.0);
+        assertThat(registry.get(METRIC_PUSH_LATENCY_SECONDS)
+                .tags(TAG_PROVIDER, providerId, TAG_RESULT, RESULT_ERROR, TAG_CODE, CODE_IO)
+                .timer().count())
+                .describedAs(String.format("%s{%s,%s,%s}", METRIC_PUSH_LATENCY_SECONDS, providerId, RESULT_ERROR, CODE_IO))
+                .isEqualTo(1);
+    }
+}

--- a/src/test/java/bisq/relay/notification/metrics/PushMetricsAutoWrapperTest.java
+++ b/src/test/java/bisq/relay/notification/metrics/PushMetricsAutoWrapperTest.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.relay.notification.metrics;
+
+import bisq.relay.notification.PushNotificationMessage;
+import bisq.relay.notification.PushNotificationResult;
+import bisq.relay.notification.PushNotificationSender;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import java.util.concurrent.CompletableFuture;
+
+import static bisq.relay.notification.metrics.PushMetrics.PROVIDER_ID_APNS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PushMetricsAutoWrapperTest {
+
+    @Configuration
+    @Import(PushMetricsAutoWrapper.class)
+    static class Cfg {
+        @Bean
+        SimpleMeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+
+        @PushProvider(PROVIDER_ID_APNS)
+        static class TestApnsSender implements PushNotificationSender {
+            @Override
+            public CompletableFuture<PushNotificationResult> sendNotification(
+                    PushNotificationMessage msg, String token) {
+                return CompletableFuture.completedFuture(
+                        new PushNotificationResult(true, null, null, false));
+            }
+        }
+
+        @Bean
+        PushNotificationSender apnsSender() {
+            return new TestApnsSender();
+        }
+    }
+
+    @Test
+    void beansAreWrappedWithMetricsDecorator() {
+        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(Cfg.class);
+        PushNotificationSender bean = ctx.getBean(PushNotificationSender.class);
+
+        assertThat(bean).isInstanceOf(MetricsPushNotificationSender.class);
+
+        // Smoke: call and ensure metrics recorded
+        bean.sendNotification(new PushNotificationMessage("foo", true), "tok").join();
+        var reg = ctx.getBean(SimpleMeterRegistry.class);
+        assertThat(reg.get(PushMetrics.METRIC_PUSH_ATTEMPTS_TOTAL)
+                .tag(PushMetrics.TAG_PROVIDER, PROVIDER_ID_APNS).counter().count()).isEqualTo(1.0);
+
+        ctx.close();
+    }
+}


### PR DESCRIPTION
- Integrated Micrometer metrics into the service
- Exposed Prometheus-compatible endpoint for scraping
- Added counters and timers:
  - push_attempts_total (number of push attempts)
  - push_total (successful pushes)
  - push_latency_seconds_bucket (latency histogram for push operations)
- Tagged metrics with relevant context (e.g., provider, result)
- Implemented Grafana dashboards for visualization of key metrics
- Add docker config to deploy a complete local test environment