### PR TITLE
feature/apns_mutable_content_flag_support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,5 +160,5 @@ The `POST /v1/apns/device/{deviceToken}` and `POST /v1/fcm/device/{deviceToken}`
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `encrypted` | string | yes | — | Encrypted notification payload |
-| `isUrgent` | boolean | yes | — | When `true`, sends as high-priority alert; when `false`, sends as background notification |
+| `isUrgent` | boolean | no | `false` | When `true`, sends as high-priority alert; when `false`, sends as background notification |
 | `isMutableContent` | boolean | no | `false` | APNs only. When `true`, sets the `mutable-content` flag in the APNs payload, allowing the iOS app's Notification Service Extension (NSE) to modify the notification content before display (e.g. for client-side decryption) |

--- a/README.md
+++ b/README.md
@@ -150,3 +150,15 @@ Once deployed, the following will be available:
 - Application management interface: http://127.0.0.1:9400 (e.g. http://127.0.0.1:9400/actuator/info)
 - Grafana: http://127.0.0.1:3000
 - Prometheus: http://127.0.0.1:9090
+
+## API Reference
+
+### Request Body
+
+The `POST /v1/apns/device/{deviceToken}` and `POST /v1/fcm/device/{deviceToken}` endpoints accept a JSON body with the following fields:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `encrypted` | string | yes | — | Encrypted notification payload |
+| `isUrgent` | boolean | yes | — | When `true`, sends as high-priority alert; when `false`, sends as background notification |
+| `isMutableContent` | boolean | no | `false` | APNs only. When `true`, sets the `mutable-content` flag in the APNs payload, allowing the iOS app's Notification Service Extension (NSE) to modify the notification content before display (e.g. for client-side decryption) |

--- a/src/main/java/bisq/relay/RelayController.java
+++ b/src/main/java/bisq/relay/RelayController.java
@@ -67,20 +67,22 @@ public class RelayController {
             @RequestParam("isAndroid") final Optional<Boolean> isAndroid,
             @RequestParam("token") final Optional<String> deviceTokenHex,
             @RequestParam("msg") final Optional<String> encryptedMessageHex,
+            @RequestParam(value = "mutableContent", required = false) final Optional<Boolean> mutableContent,
             final HttpServletRequest httpRequest) {
 
         if (LOG.isInfoEnabled()) {
-            LOG.info("Relaying notification; isAndroid={} token={} encryptedMessage={}",
+            LOG.info("Relaying notification; isAndroid={} token={} encryptedMessage={} mutableContent={}",
                     isAndroid.orElse(null),
                     maskSensitive(deviceTokenHex.orElse(null)),
-                    maskSensitive(encryptedMessageHex.orElse(null)));
+                    maskSensitive(encryptedMessageHex.orElse(null)),
+                    mutableContent.orElse(false));
         }
 
         final String deviceToken = decodeDeviceToken(deviceTokenHex);
         final String encryptedMessage = decodeParameter(encryptedMessageHex, "msg");
 
         final PushNotificationMessage pushNotificationMessage = new PushNotificationMessage(
-                encryptedMessage, true, false);
+                encryptedMessage, true, mutableContent.orElse(false));
 
         if (isAndroid.isPresent() && isAndroid.get().equals(true)) {
             if (fcmPushNotificationController == null) {

--- a/src/main/java/bisq/relay/RelayController.java
+++ b/src/main/java/bisq/relay/RelayController.java
@@ -80,7 +80,7 @@ public class RelayController {
         final String encryptedMessage = decodeParameter(encryptedMessageHex, "msg");
 
         final PushNotificationMessage pushNotificationMessage = new PushNotificationMessage(
-                encryptedMessage, true);
+                encryptedMessage, true, false);
 
         if (isAndroid.isPresent() && isAndroid.get().equals(true)) {
             if (fcmPushNotificationController == null) {

--- a/src/main/java/bisq/relay/notification/PushNotificationMessage.java
+++ b/src/main/java/bisq/relay/notification/PushNotificationMessage.java
@@ -25,13 +25,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record PushNotificationMessage(
         @Nullable String encrypted,
-        boolean isUrgent) {
+        boolean isUrgent,
+        boolean isMutableContent) {
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
                 .append("encrypted", encrypted)
                 .append("isUrgent", isUrgent)
+                .append("isMutableContent", isMutableContent)
                 .toString();
     }
 }

--- a/src/main/java/bisq/relay/notification/apns/ApnsPushNotificationBuilder.java
+++ b/src/main/java/bisq/relay/notification/apns/ApnsPushNotificationBuilder.java
@@ -71,6 +71,10 @@ public class ApnsPushNotificationBuilder {
                 .setLocalizedAlertMessage("notification")
                 .setContentAvailable(true);
 
+        if (pushNotificationMessage.isMutableContent()) {
+            payloadBuilder.setMutableContent(true);
+        }
+
         if (pushNotificationMessage.encrypted() != null) {
             payloadBuilder.addCustomProperty("encrypted", pushNotificationMessage.encrypted());
         } else {

--- a/src/test/java/bisq/relay/notification/apns/ApnsPushNotificationControllerTest.java
+++ b/src/test/java/bisq/relay/notification/apns/ApnsPushNotificationControllerTest.java
@@ -95,6 +95,29 @@ class ApnsPushNotificationControllerTest {
     }
 
     @Test
+    void whenSendApnsNotificationWithoutMutableContent_thenSuccessfulResponseReturned() throws Exception {
+        givenApnsNotificationWillBeAccepted();
+
+        // Simulate a request from an older client that does not include isMutableContent
+        String jsonWithoutMutableContent = "{\"encrypted\":\"encrypted\",\"isUrgent\":true}";
+
+        RequestBuilder requestBuilder = MockMvcRequestBuilders
+                .post("/v1/apns/device/{deviceToken}", deviceToken)
+                .headers(httpHeaders)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonWithoutMutableContent);
+        MvcResult mvcResult = mockMvc.perform(requestBuilder)
+                .andExpect(request().asyncStarted())
+                .andReturn();
+        MvcResult asyncResult = mockMvc.perform(asyncDispatch(mvcResult))
+                .andReturn();
+        assertThat(asyncResult.getResponse().getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(asyncResult.getResponse().getContentType()).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+        assertThat(asyncResult.getResponse().getContentAsString()).isEqualTo("{\"wasAccepted\":true,\"isUnregistered\":false}");
+    }
+
+    @Test
     void whenSendValidApnsNotification_thenSuccessfulResponseReturned() throws Exception {
         givenApnsNotificationWillBeAccepted();
 

--- a/src/test/java/bisq/relay/notification/apns/ApnsPushNotificationControllerTest.java
+++ b/src/test/java/bisq/relay/notification/apns/ApnsPushNotificationControllerTest.java
@@ -102,7 +102,8 @@ class ApnsPushNotificationControllerTest {
         String serializedNotificationRequest = mapper.writeValueAsString(
                 new PushNotificationMessage(
                         "encrypted",
-                        true));
+                        true,
+                        false));
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders
                 .post("/v1/apns/device/{deviceToken}", deviceToken)
@@ -128,7 +129,8 @@ class ApnsPushNotificationControllerTest {
         String serializedNotificationRequest = mapper.writeValueAsString(
                 new PushNotificationMessage(
                         "encrypted",
-                        true));
+                        true,
+                        false));
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders
                 .post("/v1/apns/device/{deviceToken}", deviceToken)
@@ -154,7 +156,8 @@ class ApnsPushNotificationControllerTest {
         String serializedNotificationRequest = mapper.writeValueAsString(
                 new PushNotificationMessage(
                         "encrypted",
-                        true));
+                        true,
+                        false));
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders
                 .post("/v1/apns/device/{deviceToken}", deviceToken)
@@ -182,7 +185,8 @@ class ApnsPushNotificationControllerTest {
         String serializedNotificationRequest = mapper.writeValueAsString(
                 new PushNotificationMessage(
                         "encrypted",
-                        true));
+                        true,
+                        false));
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders
                 .post("/v1/apns/device/{deviceToken}", deviceToken)

--- a/src/test/java/bisq/relay/notification/apns/ApnsPushNotificationSenderTest.java
+++ b/src/test/java/bisq/relay/notification/apns/ApnsPushNotificationSenderTest.java
@@ -64,8 +64,18 @@ class ApnsPushNotificationSenderTest {
     @ValueSource(booleans = {true, false})
     void whenPushNotificationIsAcceptedByApns_thenSuccessfulResultReturned(final boolean urgent) {
         givenApnsWillAcceptPushNotifications();
-        whenSendingAPushNotification(urgent);
-        thenTheSentPushNotificationIsCorrectlyPopulated(urgent);
+        whenSendingAPushNotification(urgent, false);
+        thenTheSentPushNotificationIsCorrectlyPopulated(urgent, false);
+        thenThePushNotificationWasAccepted();
+
+        verifyNoMoreInteractions(apnsClient);
+    }
+
+    @Test
+    void whenPushNotificationWithMutableContentIsAcceptedByApns_thenSuccessfulResultReturned() {
+        givenApnsWillAcceptPushNotifications();
+        whenSendingAPushNotification(true, true);
+        thenTheSentPushNotificationIsCorrectlyPopulated(true, true);
         thenThePushNotificationWasAccepted();
 
         verifyNoMoreInteractions(apnsClient);
@@ -76,8 +86,8 @@ class ApnsPushNotificationSenderTest {
     void whenPushNotificationIsRejectedByApns_thenErrorResultReturned(
             final String rejectionReason, final boolean isUnregistered, final boolean hasTokenInvalidationTimestamp) {
         givenApnsWillRejectPushNotifications(rejectionReason);
-        whenSendingAPushNotification(true);
-        thenTheSentPushNotificationIsCorrectlyPopulated(true);
+        whenSendingAPushNotification(true, false);
+        thenTheSentPushNotificationIsCorrectlyPopulated(true, false);
         thenThePushNotificationWasNotAccepted(rejectionReason, hasTokenInvalidationTimestamp, isUnregistered);
 
         verifyNoMoreInteractions(apnsClient);
@@ -87,7 +97,7 @@ class ApnsPushNotificationSenderTest {
     void whenFailedToSendNotificationToApns_thenExceptionRaised() {
         givenApnsIsUnreachable(new IOException("lost connection"));
 
-        PushNotificationMessage pushNotification = new PushNotificationMessage("foo", true);
+        PushNotificationMessage pushNotification = new PushNotificationMessage("foo", true, false);
         Throwable thrown = catchThrowable(() -> apnsSender.sendNotification(pushNotification, DEVICE_TOKEN).join());
         assertThat(thrown).isInstanceOf(CompletionException.class).hasCauseInstanceOf(IOException.class);
 
@@ -136,8 +146,8 @@ class ApnsPushNotificationSenderTest {
                                 new MockPushNotificationFuture<>(invocationOnMock.getArgument(0), exception));
     }
 
-    private void whenSendingAPushNotification(final boolean urgent) {
-        PushNotificationMessage pushNotificationMessage = new PushNotificationMessage("foo", urgent);
+    private void whenSendingAPushNotification(final boolean urgent, final boolean mutableContent) {
+        PushNotificationMessage pushNotificationMessage = new PushNotificationMessage("foo", urgent, mutableContent);
         pushNotificationResult = apnsSender.sendNotification(pushNotificationMessage, DEVICE_TOKEN).join();
 
         ArgumentCaptor<SimpleApnsPushNotification> notification = ArgumentCaptor.forClass(SimpleApnsPushNotification.class);
@@ -145,12 +155,18 @@ class ApnsPushNotificationSenderTest {
         sentPushNotification = notification.getValue();
     }
 
-    private void thenTheSentPushNotificationIsCorrectlyPopulated(final boolean urgent) {
+    private void thenTheSentPushNotificationIsCorrectlyPopulated(final boolean urgent, final boolean mutableContent) {
         assertThat(sentPushNotification.getToken()).isEqualTo(DEVICE_TOKEN);
         assertThat(sentPushNotification.getExpiration()).isCloseTo(
                 Instant.now().plus(ApnsPushNotificationBuilder.INVALIDATION_TIME_PERIOD_DAYS, DAYS), within(10, SECONDS));
-        assertThat(sentPushNotification.getPayload()).isEqualTo(
-                "{\"encrypted\":\"foo\",\"aps\":{\"alert\":{\"loc-key\":\"notification\"},\"content-available\":1}}");
+
+        if (mutableContent) {
+            assertThat(sentPushNotification.getPayload()).isEqualTo(
+                    "{\"encrypted\":\"foo\",\"aps\":{\"alert\":{\"loc-key\":\"notification\"},\"content-available\":1,\"mutable-content\":1}}");
+        } else {
+            assertThat(sentPushNotification.getPayload()).isEqualTo(
+                    "{\"encrypted\":\"foo\",\"aps\":{\"alert\":{\"loc-key\":\"notification\"},\"content-available\":1}}");
+        }
 
         assertThat(sentPushNotification.getPriority())
                 .isEqualTo(urgent ? DeliveryPriority.IMMEDIATE : DeliveryPriority.CONSERVE_POWER);

--- a/src/test/java/bisq/relay/notification/fcm/FcmPushNotificationControllerTest.java
+++ b/src/test/java/bisq/relay/notification/fcm/FcmPushNotificationControllerTest.java
@@ -101,7 +101,8 @@ class FcmPushNotificationControllerTest {
         String serializedNotificationRequest = mapper.writeValueAsString(
                 new PushNotificationMessage(
                         "encrypted",
-                        true));
+                        true,
+                        false));
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders
                 .post("/v1/fcm/device/{deviceToken}", deviceToken)
@@ -126,7 +127,8 @@ class FcmPushNotificationControllerTest {
         String serializedNotificationRequest = mapper.writeValueAsString(
                 new PushNotificationMessage(
                         "encrypted",
-                        true));
+                        true,
+                        false));
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders
                 .post("/v1/fcm/device/{deviceToken}", deviceToken)
@@ -151,7 +153,8 @@ class FcmPushNotificationControllerTest {
         String serializedNotificationRequest = mapper.writeValueAsString(
                 new PushNotificationMessage(
                         "encrypted",
-                        true));
+                        true,
+                        false));
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders
                 .post("/v1/fcm/device/{deviceToken}", deviceToken)
@@ -178,7 +181,8 @@ class FcmPushNotificationControllerTest {
         String serializedNotificationRequest = mapper.writeValueAsString(
                 new PushNotificationMessage(
                         "encrypted",
-                        true));
+                        true,
+                        false));
 
         RequestBuilder requestBuilder = MockMvcRequestBuilders
                 .post("/v1/fcm/device/{deviceToken}", deviceToken)

--- a/src/test/java/bisq/relay/notification/fcm/FcmPushNotificationSenderTest.java
+++ b/src/test/java/bisq/relay/notification/fcm/FcmPushNotificationSenderTest.java
@@ -96,7 +96,7 @@ class FcmPushNotificationSenderTest {
     void whenFailedToSendNotificationToFcm_thenExceptionRaised() {
         givenFcmIsUnreachable(new IOException("Lost connection"));
 
-        PushNotificationMessage pushNotification = new PushNotificationMessage("foo", true);
+        PushNotificationMessage pushNotification = new PushNotificationMessage("foo", true, false);
         Throwable thrown = catchThrowable(() -> fcmSender.sendNotification(pushNotification, DEVICE_TOKEN).join());
         assertThat(thrown).isInstanceOf(CompletionException.class);
 
@@ -139,7 +139,7 @@ class FcmPushNotificationSenderTest {
     }
 
     private void whenSendingAPushNotification(final boolean urgent) {
-        PushNotificationMessage pushNotificationMessage = new PushNotificationMessage("foo", urgent);
+        PushNotificationMessage pushNotificationMessage = new PushNotificationMessage("foo", urgent, false);
         pushNotificationResult = fcmSender.sendNotification(pushNotificationMessage, DEVICE_TOKEN).join();
 
         ArgumentCaptor<Message> message = ArgumentCaptor.forClass(Message.class);

--- a/src/test/java/bisq/relay/notification/metrics/MetricsPushNotificationSenderTest.java
+++ b/src/test/java/bisq/relay/notification/metrics/MetricsPushNotificationSenderTest.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class MetricsPushNotificationSenderTest {
 
-    private static final PushNotificationMessage MSG = new PushNotificationMessage("foo", true);
+    private static final PushNotificationMessage MSG = new PushNotificationMessage("foo", true, false);
 
     private static ObjectProvider<MeterRegistry> providerOf(@Nonnull final MeterRegistry registry) {
         return new ObjectProvider<>() {

--- a/src/test/java/bisq/relay/notification/metrics/PushMetricsAutoWrapperTest.java
+++ b/src/test/java/bisq/relay/notification/metrics/PushMetricsAutoWrapperTest.java
@@ -66,7 +66,7 @@ class PushMetricsAutoWrapperTest {
         assertThat(bean).isInstanceOf(MetricsPushNotificationSender.class);
 
         // Smoke: call and ensure metrics recorded
-        bean.sendNotification(new PushNotificationMessage("foo", true), "tok").join();
+        bean.sendNotification(new PushNotificationMessage("foo", true, false), "tok").join();
         var reg = ctx.getBean(SimpleMeterRegistry.class);
         assertThat(reg.get(PushMetrics.METRIC_PUSH_ATTEMPTS_TOTAL)
                 .tag(PushMetrics.TAG_PROVIDER, PROVIDER_ID_APNS).counter().count()).isEqualTo(1.0);


### PR DESCRIPTION
 - feature needed to support https://github.com/bisq-network/bisq-mobile/issues/1230
 - added support for APNs mutable content flag
 - implemented in a backward-compatible way as not all callers might want to use this (bisq1)
 - updated/added tests and docs